### PR TITLE
Fix enter key message sending

### DIFF
--- a/advencheer (js, toml, index fixes)/main.js
+++ b/advencheer (js, toml, index fixes)/main.js
@@ -199,8 +199,10 @@ function handleSendMessage() {
 
 // Event listeners with null checks
 if (messageInput) {
-    messageInput.addEventListener('keypress', (e) => {
-        if (e.key === 'Enter') {
+    messageInput.addEventListener('keydown', (e) => {
+        if (e.isComposing || e.keyCode === 229) return; // IME in progress
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
             handleSendMessage();
         }
     });


### PR DESCRIPTION
## Summary
- replace keypress handler with keydown listener for enter key

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c782fddb68832fb884e65e9f3e249c